### PR TITLE
Perp fix

### DIFF
--- a/src/perp.m
+++ b/src/perp.m
@@ -56,14 +56,20 @@ intrinsic PerpDecomposition (S::SeqEnum : Adjoint := 0) -> AlgMatElt, SeqEnum
 ============================================================================= */
 // ==== ADDED ==================================================================
     if #S eq 1 then
+
       assert IsSimple(A);
       _, _, _, phi := RecogniseClassicalSSA(A);
       idems := A`StarAlgebraInfo`primitiveIdempotents;
-      new_idems := idems @ phi;
-      assert forall{I : I in new_idems | I^2 eq I}; 
-      assert forall{I : I in new_idems | I @ A`Star in new_idems};
-      assert &+new_idems eq Generic(A)!1;
-      A`StarAlgebraInfo`primitiveIdempotents := new_idems;
+
+      // if there is a problem with the idempotents, apply this fix.
+      if exists{I : I in idems | I @ A`Star notin idems} then
+        new_idems := idems @ phi;
+        assert forall{I : I in new_idems | I^2 eq I}; 
+        assert forall{I : I in new_idems | I @ A`Star in new_idems};
+        assert &+new_idems eq Generic(A)!1;
+        A`StarAlgebraInfo`primitiveIdempotents := new_idems;
+      end if;
+
     end if;
 // =============================================================================
 


### PR DESCRIPTION
Fixed a bug that arises when the number of forms is equal to 1. This is a symptom of a deeper problem, but I think it only happens when the number of forms is 1.

I'm creating a pull request because I want give everyone the ability to reject this change if there is a better change to make that would also fix this issue with `PerpDecomposition`. 